### PR TITLE
Correct pattern not found page message

### DIFF
--- a/web-editor/src/app/p/[patternid]/notfound.tsx
+++ b/web-editor/src/app/p/[patternid]/notfound.tsx
@@ -8,7 +8,7 @@ export default function NotFound() {
   const router = useRouter()
   return (
     <div className="w-full h-full flex items-center justify-center flex-col">
-      <p>This mission doesn&apos;t exist</p>
+      <p>This pattern doesn&apos;t exist</p>
       <div className="">
         <Button onClick={() => router.refresh()}>Retry</Button>
         <Button onClick={() => router.back()}>Go Back</Button>


### PR DESCRIPTION
Replaced the word `mission` with `pattern` when a pattern is not found